### PR TITLE
Added Compute Instance, Compute Network, and Container Cluster modules

### DIFF
--- a/compute/instance/main.tf
+++ b/compute/instance/main.tf
@@ -30,6 +30,11 @@ variable "startup_script" {
     type        = string
 }
 
+variable "service_account_email" {
+    description = "The email of the service account to attach to the instance"
+    type        = string
+}
+
 # VM instance resource
 resource "google_compute_instance" "ca_lab_vm" {
     name         = "ca-lab-vm"
@@ -51,7 +56,7 @@ resource "google_compute_instance" "ca_lab_vm" {
     metadata_startup_script = var.startup_script
 
     service_account {
-        email  = module.service_account.email
+        email  = var.service_account_email
         scopes = ["https://www.googleapis.com/auth/cloud-platform"]
     }
 }

--- a/compute/instance/main.tf
+++ b/compute/instance/main.tf
@@ -1,0 +1,57 @@
+# Variables
+
+variable "machine_type" {
+    description = "The machine type to use for the instance"
+    type        = string
+}
+
+variable "zone" {
+    description = "The zone where the instance will be created"
+    type        = string
+}
+
+variable "image" {
+    description = "The image to use for the boot disk"
+    type        = string
+}
+
+variable "network_id" {
+    description = "The ID of the network to attach the instance to"
+    type        = string
+}
+
+variable "subnetwork_id" {
+    description = "The ID of the subnetwork to attach the instance to"
+    type        = string
+}
+
+variable "startup_script" {
+    description = "The startup script to run on instance creation"
+    type        = string
+}
+
+# VM instance resource
+resource "google_compute_instance" "ca_lab_vm" {
+    name         = "ca-lab-vm"
+    machine_type = var.machine_type
+    zone         = var.zone
+
+    boot_disk {
+        initialize_params {
+            image = var.image
+        }
+    }
+
+    network_interface {
+        network    = var.network_id
+        subnetwork = var.subnetwork_id
+        access_config {}
+    }
+
+    metadata_startup_script = var.startup_script
+
+    service_account {
+        email  = module.service_account.email
+        scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+    }
+}

--- a/compute/network/main.tf
+++ b/compute/network/main.tf
@@ -1,0 +1,51 @@
+# Variables
+
+variable "region" {
+    description = "The region where the instance will be created"
+    type        = string
+    default     = "us-central1"
+}
+
+variable "cidr_range" {
+    description = "The CIDR range for the subnetwork"
+    type        = string
+}
+
+# Network
+resource "google_compute_network" "vm_network" {
+  name                    = "vm-network"
+  auto_create_subnetworks = false
+}
+
+# Subnetwork
+resource "google_compute_subnetwork" "vm_subnet" {
+  name          = "vm-subnet"
+  network       = google_compute_network.vm_network.id
+  region        = var.region
+  ip_cidr_range = var.cidr_range
+}
+
+# Firewall rule to allow SSH access
+resource "google_compute_firewall" "vm_network_allow_ssh" {
+  name    = "vm-network-allow-ssh"
+  network = google_compute_network.vm_network.id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+# Outputs
+
+output "vm_network_id" {
+    description = "The ID of the VM network"
+    value       = google_compute_network.vm_network.id
+}
+
+output "vm_subnet_id" {
+    description = "The ID of the VM subnetwork"
+    value       = google_compute_subnetwork.vm_subnet.id
+}

--- a/k8s_cluster/main.tf
+++ b/k8s_cluster/main.tf
@@ -1,0 +1,81 @@
+variable "project_id" {
+    description = "The GCP project ID where the Kubernetes cluster will be created."
+    type        = string
+}
+
+variable "cluster_name" {
+    description = "The name of the Kubernetes cluster."
+    type        = string
+}
+
+variable "zone" {
+    description = "The GCP zone where the Kubernetes cluster will be deployed."
+    type        = string
+}
+
+variable "initial_node_count" {
+    description = "The initial number of nodes in the Kubernetes cluster."
+    type        = number
+    default     = 2
+}
+
+variable "machine_type" {
+    description = "The machine type to use for the Kubernetes cluster nodes."
+    type        = string
+    default     = "n1-standard-1"
+}
+
+variable "disk_size_gb" {
+    description = "The size of the disk in GB for each Kubernetes cluster node."
+    type        = number
+    default     = 10
+}
+
+variable "workload_identity" {
+    description = "Enable or disable workload identity for the Kubernetes cluster."
+    type        = bool
+    default     = false
+}
+
+variable "k8s_version" {
+    description = "The Kubernetes version to use for the cluster."
+    type        = string
+    default     = "1.32"
+}
+
+resource "google_container_cluster" "primary" {
+    name               = var.cluster_name
+    location           = var.zone
+    initial_node_count = var.initial_node_count
+
+    node_config {
+        machine_type = var.machine_type
+        disk_size_gb = var.disk_size_gb
+        oauth_scopes = [
+            "https://www.googleapis.com/auth/compute",
+            "https://www.googleapis.com/auth/devstorage.read_only",
+            "https://www.googleapis.com/auth/logging.write",
+            "https://www.googleapis.com/auth/monitoring",
+            "https://www.googleapis.com/auth/servicecontrol",
+            "https://www.googleapis.com/auth/service.management.readonly",
+            "https://www.googleapis.com/auth/trace.append",
+        ]
+
+        dynamic "workload_metadata_config" {
+            for_each = var.workload_identity ? [1] : []
+            content {
+                mode = "GKE_METADATA"
+            }
+        }
+    }
+
+    dynamic "workload_identity_config" {
+        for_each = var.workload_identity ? [1] : []
+        content {
+            workload_pool = "${var.project_id}.svc.id.goog"
+        }
+    }
+
+    min_master_version = var.k8s_version
+}
+

--- a/k8s_cluster/main.tf
+++ b/k8s_cluster/main.tf
@@ -47,6 +47,7 @@ resource "google_container_cluster" "primary" {
     name               = var.cluster_name
     location           = var.zone
     initial_node_count = var.initial_node_count
+    deletion_protection = false
 
     node_config {
         machine_type = var.machine_type


### PR DESCRIPTION
The following resources make up each module, see variables for available configs:

`compute/instance/main.tf`: 
- google_compute_instance

`compute/network/main.tf`: 
- google_compute_network
- google_compute_subnetwork
- google_compute_firewall

`k8s_cluster/main.tf`:
- google_container_cluster